### PR TITLE
Implement client channel overrides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased Changes
 
+- add `override` function to allow clients to push temporary values onto channels ([#16](https://github.com/seaofvoices/crosswalk-channels/pull/16))
 - rewrite data syncing logic ([#15](https://github.com/seaofvoices/crosswalk-channels/pull/15))
 
 ## 0.1.3

--- a/foreman.toml
+++ b/foreman.toml
@@ -1,6 +1,6 @@
 [tools]
 rojo = { github = "rojo-rbx/rojo", version = "=7.4.4"}
-selene = { github = "Kampfkarren/selene", version = "=0.27.1"}
+selene = { github = "Kampfkarren/selene", version = "=0.28.0"}
 stylua = { github = "JohnnyMorganz/StyLua", version = "=0.20.0"}
 darklua = { github = "seaofvoices/darklua", version = "=0.14.0"}
 luau-lsp = { github = "JohnnyMorganz/luau-lsp", version = "=1.35.0"}

--- a/src/impl/ClientReplication.lua
+++ b/src/impl/ClientReplication.lua
@@ -161,6 +161,11 @@ function ClientReplication:override<T>(name: string, value: T, expiration: numbe
 
     self._overrides[name] = override
 
+    local signal = self._channelSignals[name]
+    if signal then
+        signal:fire(value)
+    end
+
     task.delay(expiration, function()
         if self._overrides[name] == override then
             self._overrides[name] = nil

--- a/src/impl/ClientReplication.lua
+++ b/src/impl/ClientReplication.lua
@@ -24,16 +24,26 @@ type Private = {
     _channelSignals: { [string]: Signal<unknown> },
     _lastTimeStamps: { [string]: number },
     _lastData: { [string]: unknown },
-    _overrides: { [string]: { remainingLife: number, value: unknown } },
+    _overrides: {
+        [string]: {
+            lifeTime: number,
+            minimumOverrideTime: number,
+            value: unknown,
+        },
+    },
+    _getMinimumOverrideDuration: () -> number,
+    _timeFn: () -> number,
 }
 
 export type ClientReplicationOptions = {
     race: boolean?,
     defaultExpiration: number?,
+    getMinimumOverrideDuration: (() -> number)?,
 }
 
 local DEFAULT_RACE_OPTIONS = false
 local DEFAULT_EXPIRATION = 1.5
+local DEFAULT_STATIC_MINIMUM_OVERRIDE = 0.1
 
 type ClientReplicationStatic = ClientReplication & Private & {
     new: (options: ClientReplicationOptions?) -> ClientReplication,
@@ -55,6 +65,10 @@ function ClientReplication.new(options: ClientReplicationOptions?): ClientReplic
         _lastTimeStamps = {},
         _lastData = {},
         _overrides = {},
+        _getMinimumOverrideDuration = function()
+            return DEFAULT_STATIC_MINIMUM_OVERRIDE
+        end,
+        _timeFn = os.clock,
     }
 
     return setmetatable(self, ClientReplicationMetatable) :: any
@@ -72,6 +86,12 @@ function ClientReplication:setOptions(options: ClientReplicationOptions)
 
     if options.race ~= nil then
         self._race = options.race
+    end
+    if options.getMinimumOverrideDuration ~= nil then
+        self._getMinimumOverrideDuration = options.getMinimumOverrideDuration
+    end
+    if options.defaultExpiration ~= nil then
+        self._defaultExpiration = options.defaultExpiration
     end
 end
 
@@ -91,19 +111,33 @@ function ClientReplication:setup(parent: Instance, _player: Player): Teardown
             return
         end
 
+        local lastData = self._lastData[channelName]
+        local isEqualToLastData = compareData(lastData, data)
+
+        if not isEqualToLastData then
+            self._lastTimeStamps[channelName] = timeStamp
+            self._lastData[channelName] = data
+        end
+
+        local now = self._timeFn()
+
         local override = self._overrides[channelName]
-        self._overrides[channelName] = nil
 
-        if override ~= nil and compareData(override.value, data) then
+        if override ~= nil then
+            local passedOverrideMinimum = now >= override.minimumOverrideTime
+
+            if passedOverrideMinimum then
+                self._overrides[channelName] = nil
+            end
+
+            if compareData(override.value, data) then
+                return
+            elseif not passedOverrideMinimum then
+                return
+            end
+        elseif isEqualToLastData then
             return
         end
-
-        if compareData(self._lastData[channelName], data) then
-            return
-        end
-
-        self._lastTimeStamps[channelName] = timeStamp
-        self._lastData[channelName] = data
 
         local signal = self._channelSignals[channelName]
 
@@ -157,7 +191,11 @@ end
 function ClientReplication:override<T>(name: string, value: T, expiration: number?)
     local self: Private & ClientReplication = self :: any
 
-    local override = { remainingLife = expiration or self._defaultExpiration, value = value }
+    local override = {
+        lifeTime = expiration or self._defaultExpiration,
+        minimumOverrideTime = self._timeFn() + self._getMinimumOverrideDuration(),
+        value = value,
+    }
 
     self._overrides[name] = override
 

--- a/src/impl/ServerReplication.lua
+++ b/src/impl/ServerReplication.lua
@@ -143,13 +143,14 @@ function ServerReplication:setup(parent: Instance): () -> ()
         self._remote = remote
     end
 
+    if self._unreliableRemote == nil then
+        local unreliableRemote = Instance.new('UnreliableRemoteEvent')
+        unreliableRemote.Name = Constants.FastEventName
+        unreliableRemote.Parent = parent
+        self._unreliableRemote = unreliableRemote
+    end
+
     if self._race then
-        if self._unreliableRemote == nil then
-            local unreliableRemote = Instance.new('UnreliableRemoteEvent')
-            unreliableRemote.Name = Constants.FastEventName
-            unreliableRemote.Parent = parent
-            self._unreliableRemote = unreliableRemote
-        end
         local unreliableRemote = self._unreliableRemote :: UnreliableRemoteEvent
 
         local function onDataReceived(player: Player, channel: string, timeStamp: number)

--- a/src/impl/__tests__/compareData.test.lua
+++ b/src/impl/__tests__/compareData.test.lua
@@ -1,0 +1,86 @@
+local jestGlobals = require('@pkg/@jsdotlua/jest-globals')
+
+local expect = jestGlobals.expect
+local it = jestGlobals.it
+
+local compareData = require('../compareData')
+
+it('returns true for equal numbers', function()
+    expect(compareData(42, 42)).toEqual(true)
+end)
+
+it('returns true for equal strings', function()
+    expect(compareData('hello', 'hello')).toEqual(true)
+end)
+
+it('returns true for equal Vector3 values', function()
+    expect(compareData(Vector3.new(1, 2, 3), Vector3.new(1, 2, 3))).toEqual(true)
+end)
+
+it('returns true for equal Color3 values', function()
+    expect(compareData(Color3.new(1, 0, 0), Color3.new(1, 0, 0))).toEqual(true)
+end)
+
+it('returns true for equal Enum values', function()
+    expect(compareData(Enum.KeyCode.A, Enum.KeyCode.A)).toEqual(true)
+end)
+
+it('returns true for two nil values', function()
+    expect(compareData(nil, nil)).toEqual(true)
+end)
+
+it('returns false for unequal numbers', function()
+    expect(compareData(42, 43)).toEqual(false)
+end)
+
+it('returns false for unequal strings', function()
+    expect(compareData('hello', 'world')).toEqual(false)
+end)
+
+it('returns false for unequal Vector3 values', function()
+    expect(compareData(Vector3.new(1, 2, 3), Vector3.new(4, 5, 6))).toEqual(false)
+end)
+
+it('returns false for unequal Color3 values', function()
+    expect(compareData(Color3.new(1, 0, 0), Color3.new(0, 1, 0))).toEqual(false)
+end)
+
+it('returns false for unequal Enum values', function()
+    expect(compareData(Enum.KeyCode.A, Enum.KeyCode.B)).toEqual(false)
+end)
+
+it('returns false for a number and a string', function()
+    expect(compareData(42, '42')).toEqual(false)
+end)
+
+it('returns false for Vector3 and Color3', function()
+    expect(compareData(Vector3.new(1, 2, 3), Color3.new(1, 0, 0))).toEqual(false)
+end)
+
+it('returns false for Enum and number', function()
+    expect(compareData(Enum.KeyCode.A, 1)).toEqual(false)
+end)
+
+it('returns false for tables', function()
+    expect(compareData({ 1, 2, 3 }, { 1, 2, 3 })).toEqual(false)
+end)
+
+it('returns false for functions', function()
+    expect(compareData(function() end, function() end)).toEqual(false)
+end)
+
+it('returns false for nil and a number', function()
+    expect(compareData(nil, 42)).toEqual(false)
+end)
+
+it('returns false for a number and nil', function()
+    expect(compareData(42, nil)).toEqual(false)
+end)
+
+it('returns false for mismatched comparable types', function()
+    expect(compareData(42, '42')).toEqual(false)
+end)
+
+it('returns false for Color3 and Vector3', function()
+    expect(compareData(Color3.new(1, 0, 0), Vector3.new(1, 0, 0))).toEqual(false)
+end)

--- a/src/impl/compareData.lua
+++ b/src/impl/compareData.lua
@@ -1,0 +1,28 @@
+local COMPARABLE_TYPES = {
+    ['nil'] = true,
+    number = true,
+    string = true,
+    CFrame = true,
+    Vector2 = true,
+    Vector2int16 = true,
+    Vector3 = true,
+    Vector3int16 = true,
+    UDim = true,
+    UDim2 = true,
+    Color3 = true,
+    Enum = true,
+    EnumItem = true,
+    Rect = true,
+    Ray = true,
+}
+
+local function compareData(value1: unknown, value2: unknown): boolean
+    local valueType = typeof(value1)
+    if valueType ~= typeof(value2) then
+        return false
+    end
+
+    return COMPARABLE_TYPES[valueType] == true and value1 == value2
+end
+
+return compareData

--- a/src/init.lua
+++ b/src/init.lua
@@ -5,6 +5,7 @@ return function(_SharedModules, Services, isServer)
         race: boolean?,
         syncInterval: number?,
         timeFn: (() -> number)?,
+        defaultExpiration: number?,
     }
 
     if isServer then
@@ -156,6 +157,17 @@ return function(_SharedModules, Services, isServer)
             return clientReplication:bind(name, fn)
         end
         module.bind = module.Bind
+
+        function module.override(name: string, value: unknown, lifeTime: number?)
+            if _G.DEV then
+                assert(
+                    type(name) == 'string',
+                    string.format('expected argument #1 to be a string, received %s', type(name))
+                )
+            end
+            clientReplication:override(name, value, lifeTime)
+        end
+        module.Override = module.override
     end
 
     return module

--- a/src/init.lua
+++ b/src/init.lua
@@ -6,6 +6,7 @@ return function(_SharedModules, Services, isServer)
         syncInterval: number?,
         timeFn: (() -> number)?,
         defaultExpiration: number?,
+        getMinimumOverrideDuration: (() -> number)?,
     }
 
     if isServer then
@@ -134,7 +135,11 @@ return function(_SharedModules, Services, isServer)
     else
         local ClientReplication = require('./impl/ClientReplication')
 
-        local clientReplication = ClientReplication.new()
+        local clientReplication = ClientReplication.new({
+            getMinimumOverrideDuration = function()
+                return Services.Players.LocalPlayer:GetNetworkPing()
+            end,
+        })
 
         function module.configure(config: Configuration)
             clientReplication:setOptions(config)


### PR DESCRIPTION
Add a new function `Channels.override` to temporary alter the value present in the channel for a limited amount of time.

- [x] add entry to the changelog
